### PR TITLE
Custom Frontier selection and exploration

### DIFF
--- a/explore/include/explore/distance.h
+++ b/explore/include/explore/distance.h
@@ -1,0 +1,11 @@
+#ifndef DISTANCE_H
+#define DISTANCE_H
+
+#include <cmath>
+#include <geometry_msgs/Point.h>  
+
+inline double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
+    return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
+}
+
+#endif // DISTANCE_H

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -106,7 +106,7 @@ private:
 
   // parameters
   double planner_frequency_;
-  double potential_scale_, orientation_scale_, gain_scale_, cluster_radius_;
+  double potential_scale_, orientation_scale_, gain_scale_, min_frontier_spacing_;
   ros::Duration progress_timeout_;
   bool visualize_;
 };

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -106,7 +106,7 @@ private:
 
   // parameters
   double planner_frequency_;
-  double potential_scale_, orientation_scale_, gain_scale_;
+  double potential_scale_, orientation_scale_, gain_scale_, cluster_radius_;
   ros::Duration progress_timeout_;
   bool visualize_;
 };

--- a/explore/include/explore/explore.h
+++ b/explore/include/explore/explore.h
@@ -89,6 +89,7 @@ private:
   ros::NodeHandle relative_nh_;
   ros::Publisher marker_array_publisher_;
   tf::TransformListener tf_listener_;
+  ros::Publisher termination_publisher;
 
   Costmap2DClient costmap_client_;
   actionlib::SimpleActionClient<move_base_msgs::MoveBaseAction>

--- a/explore/include/explore/frontier_search.h
+++ b/explore/include/explore/frontier_search.h
@@ -35,7 +35,7 @@ public:
    * @param costmap Reference to costmap data to search.
    */
   FrontierSearch(costmap_2d::Costmap2D* costmap, double potential_scale,
-                 double gain_scale, double min_frontier_size, double cluster_radius);
+                 double gain_scale, double min_frontier_size, double min_frontier_spacing);
 
   /**
    * @brief Runs search implementation, outward from the start position
@@ -83,7 +83,7 @@ private:
   unsigned int size_x_, size_y_;
   double potential_scale_, gain_scale_;
   double min_frontier_size_;
-  double cluster_radius_;
+  double min_frontier_spacing_;
 };
 }
 #endif

--- a/explore/include/explore/frontier_search.h
+++ b/explore/include/explore/frontier_search.h
@@ -35,7 +35,7 @@ public:
    * @param costmap Reference to costmap data to search.
    */
   FrontierSearch(costmap_2d::Costmap2D* costmap, double potential_scale,
-                 double gain_scale, double min_frontier_size);
+                 double gain_scale, double min_frontier_size, double cluster_radius);
 
   /**
    * @brief Runs search implementation, outward from the start position
@@ -83,6 +83,7 @@ private:
   unsigned int size_x_, size_y_;
   double potential_scale_, gain_scale_;
   double min_frontier_size_;
+  double cluster_radius_;
 };
 }
 #endif

--- a/explore/launch/explore.launch
+++ b/explore/launch/explore.launch
@@ -11,10 +11,10 @@
   <param name="gain_scale" value="1.0"/>
   <param name="transform_tolerance" value="0.3"/>
   <param name="min_frontier_size" value="0.75"/>
-  <param name="filter_radius" value="4.0"/>
-  <param name="radius_switch_num" value="2.0"/>
-  <param name="termination_num" value="30.0"/>
-  <param name="wholemap_radius" value="15.0"/>
-  <param name="cluster_radius" value="2.0"/>
+  <param name="local_frontier_filter_radius" value="4.0"/>
+  <param name="min_local_frontiers" value="2.0"/>
+  <param name="min_global_frontiers" value="30.0"/>
+  <param name="global_frontier_filter_radius" value="15.0"/>
+  <param name="min_frontier_spacing" value="2.0"/>
 </node>
 </launch>

--- a/explore/launch/explore.launch
+++ b/explore/launch/explore.launch
@@ -11,5 +11,9 @@
   <param name="gain_scale" value="1.0"/>
   <param name="transform_tolerance" value="0.3"/>
   <param name="min_frontier_size" value="0.75"/>
+  <param name="filter_radius" value="4.0"/>
+  <param name="radius_switch_num" value="1.0"/>
+  <param name="termination_num" value="2.0"/>
+  <param name="wholemap_radius" value="15.0"/>
 </node>
 </launch>

--- a/explore/launch/explore.launch
+++ b/explore/launch/explore.launch
@@ -13,7 +13,8 @@
   <param name="min_frontier_size" value="0.75"/>
   <param name="filter_radius" value="4.0"/>
   <param name="radius_switch_num" value="2.0"/>
-  <param name="termination_num" value="3.0"/>
+  <param name="termination_num" value="30.0"/>
   <param name="wholemap_radius" value="15.0"/>
+  <param name="cluster_radius" value="2.0"/>
 </node>
 </launch>

--- a/explore/launch/explore.launch
+++ b/explore/launch/explore.launch
@@ -12,8 +12,8 @@
   <param name="transform_tolerance" value="0.3"/>
   <param name="min_frontier_size" value="0.75"/>
   <param name="filter_radius" value="4.0"/>
-  <param name="radius_switch_num" value="1.0"/>
-  <param name="termination_num" value="2.0"/>
+  <param name="radius_switch_num" value="2.0"/>
+  <param name="termination_num" value="3.0"/>
   <param name="wholemap_radius" value="15.0"/>
 </node>
 </launch>

--- a/explore/launch/explore_n_save.launch
+++ b/explore/launch/explore_n_save.launch
@@ -11,11 +11,11 @@
   <param name="gain_scale" value="1.0"/>
   <param name="transform_tolerance" value="0.3"/>
   <param name="min_frontier_size" value="0.75"/>
-  <param name="filter_radius" value="4.0"/>
-  <param name="radius_switch_num" value="3.0"/>
-  <param name="termination_num" value="3.0"/>
-  <param name="wholemap_radius" value="15.0"/>
-  <param name="cluster_radius" value="2.0"/>
+  <param name="local_frontier_filter_radius" value="4.0"/>
+  <param name="min_local_frontiers" value="3.0"/>
+  <param name="min_global_frontiers" value="30.0"/>
+  <param name="global_frontier_filter_radius" value="15.0"/>
+  <param name="min_frontier_spacing" value="2.0"/>
 </node>
 <node pkg="explore_lite" type="savemap.py" name="savemap" output="screen">
 </node>

--- a/explore/launch/explore_n_save.launch
+++ b/explore/launch/explore_n_save.launch
@@ -15,6 +15,7 @@
   <param name="radius_switch_num" value="3.0"/>
   <param name="termination_num" value="3.0"/>
   <param name="wholemap_radius" value="15.0"/>
+  <param name="cluster_radius" value="2.0"/>
 </node>
 <node pkg="explore_lite" type="savemap.py" name="savemap" output="screen">
 </node>

--- a/explore/launch/explore_n_save.launch
+++ b/explore/launch/explore_n_save.launch
@@ -12,8 +12,8 @@
   <param name="transform_tolerance" value="0.3"/>
   <param name="min_frontier_size" value="0.75"/>
   <param name="filter_radius" value="4.0"/>
-  <param name="radius_switch_num" value="2.0"/>
-  <param name="termination_num" value="10.0"/>
+  <param name="radius_switch_num" value="3.0"/>
+  <param name="termination_num" value="3.0"/>
   <param name="wholemap_radius" value="15.0"/>
 </node>
 <node pkg="explore_lite" type="savemap.py" name="savemap" output="screen">

--- a/explore/launch/explore_n_save.launch
+++ b/explore/launch/explore_n_save.launch
@@ -1,0 +1,21 @@
+<launch>
+<node pkg="explore_lite" type="explore" respawn="false" name="explore" output="screen">
+  <param name="robot_base_frame" value="base_link"/>
+  <param name="costmap_topic" value="map"/>
+  <param name="costmap_updates_topic" value="map_updates"/>
+  <param name="visualize" value="true"/>
+  <param name="planner_frequency" value="0.33"/>
+  <param name="progress_timeout" value="30.0"/>
+  <param name="potential_scale" value="3.0"/>
+  <param name="orientation_scale" value="0.0"/>
+  <param name="gain_scale" value="1.0"/>
+  <param name="transform_tolerance" value="0.3"/>
+  <param name="min_frontier_size" value="0.75"/>
+  <param name="filter_radius" value="4.0"/>
+  <param name="radius_switch_num" value="2.0"/>
+  <param name="termination_num" value="10.0"/>
+  <param name="wholemap_radius" value="15.0"/>
+</node>
+<node pkg="explore_lite" type="savemap.py" name="savemap" output="screen">
+</node>
+</launch>

--- a/explore/scripts/savemap.py
+++ b/explore/scripts/savemap.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import rospy
+from std_msgs.msg import Bool
+import os
+
+class saveMap():
+    def __init__(self):
+        self.is_terminate = False
+        rospy.init_node("savemap")
+        rospy.Subscriber("explore/exploration_termination", Bool, self.callback_termination)
+        #print(f"node initialised successfully")
+        rospy.spin()
+
+
+    def callback_termination(self, is_terminated):
+        #print(f"termination condition received")
+        assert is_terminated.data == True
+        os.system("rosrun map_server map_saver -f ~/mymap")
+
+
+if __name__=="__main__":
+    saveMap()
+    
+

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -38,6 +38,7 @@
 #include <explore/explore.h>
 
 #include <thread>
+#include <explore/distance.h>
 
 inline static bool operator==(const geometry_msgs::Point& one,
                               const geometry_msgs::Point& two)
@@ -48,9 +49,9 @@ inline static bool operator==(const geometry_msgs::Point& one,
   return dist < 0.01;
 }
 
-double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
-  return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
-}
+// double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
+//   return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
+// }
 double filter_radius;
 double radius_switch_num;
 double termination_num;

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -198,6 +198,18 @@ void Explore::makePlan()
       filtered_frontiers.push_back(frontiers[i]);
     }
 
+  if (filtered_frontiers.size() <= radius_switch_num ) {
+    radius_ = wholemap_radius;
+    filtered_frontiers = frontiers; // Pass all the frontiers to pick from. 
+    ROS_INFO("****Not enough frontiers within the filter radius || Expanding search to whole map\n****");
+    ROS_DEBUG("****** current radius is --- %.2f\n********", radius_);
+  }
+  else{
+    ROS_INFO("****Picking a frontier within the filter radius \n****");
+    radius_ = filter_radius;
+    ROS_DEBUG("****** current radius is --- %.2f\n********", radius_);
+  }
+
   // publish frontiers as visualization markers
   if (visualize_) {
     visualizeFrontiers(frontiers);

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -152,7 +152,7 @@ void Explore::visualizeFrontiers(
     ++id;
     m.type = visualization_msgs::Marker::SPHERE;
     m.id = int(id);
-    m.pose.position = frontier.initial;
+    m.pose.position = frontier.centroid;
     // scale frontier according to its cost (costier frontiers will be smaller)
     double scale = std::min(std::abs(min_cost * 0.4 / frontier.cost), 0.5);
     m.scale.x = scale;

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -190,7 +190,8 @@ void Explore::makePlan()
     ROS_DEBUG("frontier %zd cost: %f", i, frontiers[i].cost);
   }
 
-  if (frontiers.empty()) {
+  // exploration termination condition;
+  if (frontiers.size() < termination_num){
     stop();
     return;
   }
@@ -221,7 +222,8 @@ void Explore::makePlan()
                        [this](const frontier_exploration::Frontier& f) {
                          return goalOnBlacklist(f.centroid);
                        });
-  if (frontier == frontiers.end()) {
+  // TODO: check this stop condition 
+  if (frontier == filtered_frontiers.end()) {
     stop();
     return;
   }

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -254,7 +254,7 @@ void Explore::makePlan()
                       });
   
   // TODO: check this stop condition 
-  if (frontier == filtered_frontiers.end()) {
+  if (frontier == filtered_frontiers.end() && (radius_ == wholemap_radius)) {
     stop();
     return;
   }

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -47,6 +47,7 @@ inline static bool operator==(const geometry_msgs::Point& one,
   double dist = sqrt(dx * dx + dy * dy);
   return dist < 0.01;
 }
+
 double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
   return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
 }
@@ -194,19 +195,29 @@ void Explore::makePlan()
   auto pose = costmap_client_.getRobotPose();
   // get frontiers sorted according to cost
   auto frontiers = search_.searchFrom(pose.position);
-  ROS_DEBUG("found %lu frontiers", frontiers.size());
-  for (size_t i = 0; i < frontiers.size(); ++i) {
-    ROS_DEBUG("frontier %zd cost: %f", i, frontiers[i].cost);
-  }
 
   // exploration termination condition;
   if (frontiers.size() < termination_num){
     stop();
     return;
   }
+
+  // a new frontier list for filtering frontiers only within the filter_radius of robot
+  std::vector<frontier_exploration::Frontier> filtered_frontiers;
+  double radius_ = 8.0;
+  radius_ = filter_radius;
+
+  ROS_DEBUG("found %lu frontiers from whole map\n", frontiers.size());
+  for (size_t i = 0; i < frontiers.size(); ++i) {
+    ROS_DEBUG("whole map frontier %zd cost: %f", i, frontiers[i].cost);
     if (euclideanDistance(pose.position, frontiers[i].centroid) <= radius_) {
       filtered_frontiers.push_back(frontiers[i]);
     }
+  }
+  ROS_DEBUG("filtered frontiers within filter_radius: %lu", filtered_frontiers.size());
+  // for (size_t i = 0; i < filtered_frontiers.size(); ++i) {
+  //   ROS_DEBUG("filtered frontier %zd cost: %f", i, filtered_frontiers[i].cost);
+  // }
 
   if (filtered_frontiers.size() <= radius_switch_num ) {
     radius_ = wholemap_radius;
@@ -220,17 +231,28 @@ void Explore::makePlan()
     ROS_DEBUG("****** current radius is --- %.2f\n********", radius_);
   }
 
-  // publish frontiers as visualization markers
-  if (visualize_) {
-    visualizeFrontiers(frontiers);
-  }
+  // if (frontiers.empty()) {
+  //   stop();
+  //   return;
+  // }
+  
 
+  // publish frontiers as visualization markers
+  // if (filtered_frontiers.size() > termination_num){
+  //   if (visualize_) {
+  //     visualizeFrontiers(filtered_frontiers);
+  //   }
+  // }
+  if (visualize_) {
+      visualizeFrontiers(filtered_frontiers);
+  }
   // find non blacklisted frontier
   auto frontier =
-      std::find_if_not(frontiers.begin(), frontiers.end(),
-                       [this](const frontier_exploration::Frontier& f) {
-                         return goalOnBlacklist(f.centroid);
-                       });
+      std::find_if_not(filtered_frontiers.begin(), filtered_frontiers.end(),
+                      [this](const frontier_exploration::Frontier& f) {
+                        return goalOnBlacklist(f.centroid);
+                      });
+  
   // TODO: check this stop condition 
   if (frontier == filtered_frontiers.end()) {
     stop();
@@ -271,10 +293,16 @@ void Explore::makePlan()
                 const move_base_msgs::MoveBaseResultConstPtr& result) {
         reachedGoal(status, result, target_position);
       });
+
 }
+  
+
+  
+
 
 bool Explore::goalOnBlacklist(const geometry_msgs::Point& goal)
 {
+  // TODO: explore the funactionality by change of tolerance;
   constexpr static size_t tolerace = 5;
   costmap_2d::Costmap2D* costmap2d = costmap_client_.getCostmap();
 

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -58,6 +58,7 @@ double filter_radius;
 double radius_switch_num;
 double termination_num;
 double wholemap_radius;
+double cluster_radius;
 
 namespace explore
 {
@@ -83,11 +84,12 @@ Explore::Explore()
   private_nh_.param("radius_switch_num", radius_switch_num, 5.0);
   private_nh_.param("termination_num", termination_num, 5.0);
   private_nh_.param("wholemap_radius", wholemap_radius, 5.0);
+  private_nh_.param("cluster_radius", cluster_radius, 2.0);
 
-  ROS_INFO("Params: \n filter_radius: %f \n radius_switch_num: %f \n termination_num: %f", filter_radius, radius_switch_num, termination_num);
+  ROS_INFO("Params: \n filter_radius: %f \n radius_switch_num: %f \n termination_num: %f \n cluster_radius: %f", filter_radius, radius_switch_num, termination_num, cluster_radius);
   search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
                                                  potential_scale_, gain_scale_,
-                                                 min_frontier_size);
+                                                 min_frontier_size, cluster_radius);
   termination_publisher = private_nh_.advertise<std_msgs::Bool>("exploration_termination", 10);
   if (visualize_) {
     marker_array_publisher_ =

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -39,6 +39,8 @@
 
 #include <thread>
 #include <explore/distance.h>
+#include <std_srvs/Empty.h>
+#include <std_msgs/Bool.h>
 
 inline static bool operator==(const geometry_msgs::Point& one,
                               const geometry_msgs::Point& two)
@@ -86,7 +88,7 @@ Explore::Explore()
   search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
                                                  potential_scale_, gain_scale_,
                                                  min_frontier_size);
-
+  termination_publisher = private_nh_.advertise<std_msgs::Bool>("exploration_termination", 10);
   if (visualize_) {
     marker_array_publisher_ =
         private_nh_.advertise<visualization_msgs::MarkerArray>("frontiers", 10);
@@ -197,8 +199,11 @@ void Explore::makePlan()
   // get frontiers sorted according to cost
   auto frontiers = search_.searchFrom(pose.position);
 
+  std_msgs::Bool exploration_termination;
   // exploration termination condition;
   if (frontiers.size() < termination_num){
+    exploration_termination.data = true;
+    termination_publisher.publish(exploration_termination);
     stop();
     return;
   }

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -47,6 +47,9 @@ inline static bool operator==(const geometry_msgs::Point& one,
   double dist = sqrt(dx * dx + dy * dy);
   return dist < 0.01;
 }
+double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
+  return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
+}
 
 namespace explore
 {
@@ -191,6 +194,9 @@ void Explore::makePlan()
     stop();
     return;
   }
+    if (euclideanDistance(pose.position, frontiers[i].centroid) <= radius_) {
+      filtered_frontiers.push_back(frontiers[i]);
+    }
 
   // publish frontiers as visualization markers
   if (visualize_) {

--- a/explore/src/explore.cpp
+++ b/explore/src/explore.cpp
@@ -50,6 +50,10 @@ inline static bool operator==(const geometry_msgs::Point& one,
 double euclideanDistance(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
   return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
 }
+double filter_radius;
+double radius_switch_num;
+double termination_num;
+double wholemap_radius;
 
 namespace explore
 {
@@ -71,7 +75,12 @@ Explore::Explore()
   private_nh_.param("orientation_scale", orientation_scale_, 0.0);
   private_nh_.param("gain_scale", gain_scale_, 1.0);
   private_nh_.param("min_frontier_size", min_frontier_size, 0.5);
+  private_nh_.param("filter_radius", filter_radius, 5.0);
+  private_nh_.param("radius_switch_num", radius_switch_num, 5.0);
+  private_nh_.param("termination_num", termination_num, 5.0);
+  private_nh_.param("wholemap_radius", wholemap_radius, 5.0);
 
+  ROS_INFO("Params: \n filter_radius: %f \n radius_switch_num: %f \n termination_num: %f", filter_radius, radius_switch_num, termination_num);
   search_ = frontier_exploration::FrontierSearch(costmap_client_.getCostmap(),
                                                  potential_scale_, gain_scale_,
                                                  min_frontier_size);

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -21,11 +21,12 @@ using costmap_2d::FREE_SPACE;
 
 FrontierSearch::FrontierSearch(costmap_2d::Costmap2D* costmap,
                                double potential_scale, double gain_scale,
-                               double min_frontier_size)
+                               double min_frontier_size, double cluster_radius)
   : costmap_(costmap)
   , potential_scale_(potential_scale)
   , gain_scale_(gain_scale)
   , min_frontier_size_(min_frontier_size)
+  , cluster_radius_(cluster_radius)
 {
 }
 
@@ -87,7 +88,7 @@ std::vector<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position)
         if (new_frontier.size * costmap_->getResolution() >= min_frontier_size_) {
           bool too_close = false;
           for (const auto& frontier : frontier_list) {
-            if (euclideanDistance(new_frontier.centroid, frontier.centroid) < 3.0) {
+            if (euclideanDistance(new_frontier.centroid, frontier.centroid) < cluster_radius_) {
               too_close = true;
               break;
             }

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -8,6 +8,10 @@
 
 #include <explore/costmap_tools.h>
 
+double euclideanDistancee(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
+  return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
+}
+
 namespace frontier_exploration
 {
 using costmap_2d::LETHAL_OBSTACLE;
@@ -75,9 +79,21 @@ std::vector<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position)
       } else if (isNewFrontierCell(nbr, frontier_flag)) {
         frontier_flag[nbr] = true;
         Frontier new_frontier = buildNewFrontier(nbr, pos, frontier_flag);
-        if (new_frontier.size * costmap_->getResolution() >=
-            min_frontier_size_) {
-          frontier_list.push_back(new_frontier);
+        // if (new_frontier.size * costmap_->getResolution() >=
+        //     min_frontier_size_) {
+        //   frontier_list.push_back(new_frontier);
+        // }
+        if (new_frontier.size * costmap_->getResolution() >= min_frontier_size_) {
+          bool too_close = false;
+          for (const auto& frontier : frontier_list) {
+            if (euclideanDistancee(new_frontier.centroid, frontier.centroid) < 3.0) {
+              too_close = true;
+              break;
+            }
+          }
+          if (!too_close) {
+            frontier_list.push_back(new_frontier);
+          }
         }
       }
     }

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -21,12 +21,12 @@ using costmap_2d::FREE_SPACE;
 
 FrontierSearch::FrontierSearch(costmap_2d::Costmap2D* costmap,
                                double potential_scale, double gain_scale,
-                               double min_frontier_size, double cluster_radius)
+                               double min_frontier_size, double min_frontier_spacing)
   : costmap_(costmap)
   , potential_scale_(potential_scale)
   , gain_scale_(gain_scale)
   , min_frontier_size_(min_frontier_size)
-  , cluster_radius_(cluster_radius)
+  , min_frontier_spacing_(min_frontier_spacing)
 {
 }
 
@@ -88,7 +88,7 @@ std::vector<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position)
         if (new_frontier.size * costmap_->getResolution() >= min_frontier_size_) {
           bool too_close = false;
           for (const auto& frontier : frontier_list) {
-            if (euclideanDistance(new_frontier.centroid, frontier.centroid) < cluster_radius_) {
+            if (euclideanDistance(new_frontier.centroid, frontier.centroid) < min_frontier_spacing_) {
               too_close = true;
               break;
             }

--- a/explore/src/frontier_search.cpp
+++ b/explore/src/frontier_search.cpp
@@ -7,10 +7,11 @@
 #include <geometry_msgs/Point.h>
 
 #include <explore/costmap_tools.h>
+#include <explore/distance.h>
 
-double euclideanDistancee(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
-  return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
-}
+// double euclideanDistancee(const geometry_msgs::Point& p1, const geometry_msgs::Point& p2) {
+//   return std::sqrt(std::pow(p1.x - p2.x, 2) + std::pow(p1.y - p2.y, 2));
+// }
 
 namespace frontier_exploration
 {
@@ -86,7 +87,7 @@ std::vector<Frontier> FrontierSearch::searchFrom(geometry_msgs::Point position)
         if (new_frontier.size * costmap_->getResolution() >= min_frontier_size_) {
           bool too_close = false;
           for (const auto& frontier : frontier_list) {
-            if (euclideanDistancee(new_frontier.centroid, frontier.centroid) < 3.0) {
+            if (euclideanDistance(new_frontier.centroid, frontier.centroid) < 3.0) {
               too_close = true;
               break;
             }


### PR DESCRIPTION
Reconfigured the m-explore ros package for efficient realworld exploration with custom parameters:
- local_frontier_filter_radius
- min_local_frontiers
- min_global_frontiers
- global_frontier_filter_radius`
- min_frontier_spacing